### PR TITLE
Phase-in stable identifiers for all "referenced" components.

### DIFF
--- a/config_schema.yml
+++ b/config_schema.yml
@@ -12,17 +12,23 @@ components:
 
   schemas:
 
-    Field:
+    ReferencedEntity:
       type: object
       properties:
-        name:
-          type: string
-          description: the name of the field
         stableId:
           type: string
-          description: the stableId is the immutable identity of the field, and remains the same even if the name changes. If omitted, the appliance will generate a stableId for you. If included, the appliance will use the stableId you provide.
-      required:
-        - name
+          description: An immutable identity that is stable even as associated human-readable names change.
+
+    Field:
+      allOf:
+        - $ref: '#/components/schemas/ReferencedEntity'
+        - type: object
+          properties:
+            name:
+              type: string
+              description: the name of the field
+          required:
+            - name
 
     Details:
       type: object
@@ -45,16 +51,14 @@ components:
     Category:
       allOf:
         - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
             fields:
               type: array
-              items: 
+              items:
                 $ref: '#/components/schemas/Field'
               description: a collection of named fields describing distinct instances and varieties of this category of data
-            stableId:
-              type: string
-              description: the stableId is the immutable identity of the category, and remains the same even if the name changes. If omitted, the appliance will generate a stableId for you. If included, the appliance will use the stableId you provide.
           required:
             - fields
 
@@ -76,8 +80,9 @@ components:
     AbstractPurpose:
       allOf:
         - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/ReferencedEntity'
 
-    PurposeNames:
+    PurposeIdentifiers:
       type: array
       items:
         type: string
@@ -98,7 +103,7 @@ components:
               items:
                 type: string
             allowedPurposes:
-              $ref: '#/components/schemas/PurposeNames'
+              $ref: '#/components/schemas/PurposeIdentifiers'
           required:
             - propertyName
             - values
@@ -141,6 +146,7 @@ components:
     ThirdParty:
       allOf:
         - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
             categories:
@@ -192,6 +198,7 @@ components:
     ConsentTerms:
       allOf:
         - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
             requestedCategories:
@@ -224,6 +231,7 @@ components:
     ContractTerms:
       allOf:
         - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
             contractAccess:
@@ -232,12 +240,12 @@ components:
             userAccess:
               description: the set of categories that a user is allowed under contract terms
               $ref: '#/components/schemas/CategoryIdentifiers'
-            platformUsePurposes:
+            platformUsePurposeIds:
               description: the set of Platform Use Purposes that are allowed under contract terms
-              $ref: '#/components/schemas/PurposeNames'
-            platformSharingPurposes:
+              $ref: '#/components/schemas/PurposeIdentifiers'
+            platformSharingPurposeIds:
               description: the set of Platform Sharing Purposes that are allowed under contract terms
-              $ref: '#/components/schemas/PurposeNames'
+              $ref: '#/components/schemas/PurposeIdentifiers'
 
     ContractualExchangePurpose:
       allOf:
@@ -264,7 +272,7 @@ components:
 
     UserAccess:
       allOf:
-        - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/Details'
         - type: object
           properties:
             categories:
@@ -309,16 +317,16 @@ components:
         type: object
         title: PurposeWithParties
         properties:
-          purposeName:
+          purposeId:
             type: string
-          thirdParties:
+          thirdPartyIds:
             type: array
             items:
               type: string
 
     GuardianAccess:
       allOf:
-        - $ref: '#/components/schemas/EntityWithDetails'
+        - $ref: '#/components/schemas/Details'
         - type: object
           properties:
             thresholdAge:

--- a/config_schema.yml
+++ b/config_schema.yml
@@ -117,7 +117,7 @@ components:
         - $ref: '#/components/schemas/AbstractPurpose'
         - type: object
           properties:
-            categories:
+            categoryIds:
               description: the set of categories that are valid for this platform use purpose
               $ref: '#/components/schemas/CategoryIdentifiers'
             optIn:
@@ -125,7 +125,7 @@ components:
               description: true if this platform use purpose is only enabled by user opt-in
               default: false
           required:
-            - categories
+            - categoryIds
 
     PlatformUsePurposes:
       type: object
@@ -153,21 +153,19 @@ components:
         - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
-            categories:
+            categoryIds:
               description: The set of categories allowed for sharing with this party, or empty to use the purpose ceiling
               $ref: '#/components/schemas/CategoryIdentifiers'
             serviceProvider:
               type: boolean
               default: false
-          required:
-            - name
 
     PlatformSharingPurpose:
       allOf:
         - $ref: '#/components/schemas/AbstractPurpose'
         - type: object
           properties:
-            categoryCeiling:
+            categoryCeilingIds:
               description: the upper-bound of categories available for this platform sharing purpose
               $ref: '#/components/schemas/CategoryIdentifiers'
             thirdParties:
@@ -176,7 +174,7 @@ components:
               items:
                 $ref: '#/components/schemas/ThirdParty'
           required:
-            - categoryCeiling
+            - categoryCeilingIds
             - thirdParties
 
     PlatformSharingPurposes:
@@ -205,7 +203,7 @@ components:
         - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
-            requestedCategories:
+            requestedCategoryIds:
               description: the set of categories requested under these consent terms
               $ref: '#/components/schemas/CategoryIdentifiers'
 
@@ -238,10 +236,10 @@ components:
         - $ref: '#/components/schemas/ReferencedEntity'
         - type: object
           properties:
-            contractAccess:
+            contractAccessCategoryIds:
               description: the set of categories that may be shared under the contract terms
               $ref: '#/components/schemas/CategoryIdentifiers'
-            userAccess:
+            userAccessCategoryIds:
               description: the set of categories that a user is allowed under contract terms
               $ref: '#/components/schemas/CategoryIdentifiers'
             platformUsePurposeIds:
@@ -279,7 +277,7 @@ components:
         - $ref: '#/components/schemas/Details'
         - type: object
           properties:
-            categories:
+            categoryIds:
               $ref: '#/components/schemas/CategoryIdentifiers'
           required:
             - categories
@@ -299,7 +297,7 @@ components:
               type: array
               items:
                 type: string
-            allowedCategories:
+            allowedCategoryIds:
               $ref: '#/components/schemas/CategoryIdentifiers'
           required:
             - propertyName
@@ -335,13 +333,13 @@ components:
           properties:
             thresholdAge:
               type: integer
-            categories:
+            categoryIds:
               $ref: '#/components/schemas/CategoryIdentifiers'
             allowedToDisable:
               $ref: '#/components/schemas/PlatformSharingParties'
           required:
             - thresholdAge
-            - categories
+            - categoryIds
 
     ChangedTermsDefaultBehavior:
       type: object

--- a/config_schema.yml
+++ b/config_schema.yml
@@ -17,7 +17,11 @@ components:
       properties:
         stableId:
           type: string
-          description: An immutable identity that is stable even as associated human-readable names change.
+          description: |
+            An immutable identity that is stable even as associated human-readable names change. This identity must be
+            globally unique, so that any given entity (e.g., a Category or a Purpose) can be uniquly identified.
+      required:
+        - stableId
 
     Field:
       allOf:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -219,7 +219,7 @@ paths:
                 affirmativeConsents:
                   - purposeId: 'TrainAlgorithm'
                     termsId: 'AIstartup3'
-                    categories:
+                    categoryIds:
                       - email
                       - address
       responses:
@@ -1400,11 +1400,11 @@ components:
             - $ref: '#/components/schemas/ContractualRelationship'
             - type: object
               properties:
-                categories:
+                categoryIds:
                   description: the categories of data associated with the user shared with the contractual entity
                   $ref: './config_schema.yml#/components/schemas/CategoryIdentifiers'
               required:
-                - categories
+                - categoryIds
           title: ContractualCategories
       required:
         - categories
@@ -1431,11 +1431,9 @@ components:
         termsId:
           type: string
           description: the terms describing this consented sharing
-        categories:
-          type: array
+        categoryIds:
           description: the set of categories that a user consents to share through this relationship
-          items:
-            type: string
+          $ref: './config_schema.yml#/components/schemas/CategoryIdentifiers'
       required:
         - consentedParty
         - purpose
@@ -1446,11 +1444,9 @@ components:
         userId:
           type: string
           description: the identity of a user who is allowed shared data through this relationship
-        categories:
-          type: array
+        categoryIds:
           description: the set of categories that a user consents to share through this relationship
-          items:
-            type: string
+          $ref: './config_schema.yml#/components/schemas/CategoryIdentifiers'
       required:
         - userId
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@
 # Note that this definition uses two patterns that OpenAPI generators ignore by default:
 #  1. alias to array
 #  2. form models
-# As such, to generate full documentatin or code from this specification you must set
+# As such, to generate full documentation or code from this specification you must set
 # "generateAliasAsModel" to true and "skipFormModel" to false. For instance, when using the
 # generator CLI you should specify:
 #   $ openapi-generator generate -i [file.yml] --generate-alias-as-model --global-property "skipFormModel=false" -g [...]
@@ -457,13 +457,13 @@ paths:
             type: string
           required: false
         - in: query
-          name: contractualPurpose
+          name: contractualPurposeId
           description: the purpose of a contractual relationship, which requires a value for `contractualTerms`
           schema:
             type: string
           required: false
         - in: query
-          name: contractualTerms
+          name: contractualTermsId
           description: the terms of a contractual relationship, which requires a value for `contractualPurpose`
           schema:
             type: string
@@ -811,11 +811,11 @@ paths:
       operationId: getPlatormUses
       parameters:
         - in: query
-          name: purposeName
+          name: purposeId
           schema:
             type: string
           required: false
-          description: if present, only the named purpose will be returned
+          description: if present, only the identified purpose will be returned
       responses:
         '200':
           description: OK
@@ -824,7 +824,7 @@ paths:
               schema:
                 $ref: './config_schema.yml#/components/schemas/PlatformUsePurposes'
         '404':
-          description: A purposeName was present, but the identified platform use purpose is unknown.
+          description: A purposeId was present, but the identified platform use purpose is unknown.
         '500':
           description: An internal error occured trying to retrieve the requested platform use purpose.
 
@@ -859,11 +859,11 @@ paths:
       operationId: getPlatormSharing
       parameters:
         - in: query
-          name: purposeName
+          name: purposeId
           schema:
             type: string
           required: false
-          description: if present, only the named purpose will be returned
+          description: if present, only the identified purpose will be returned
       responses:
         '200':
           description: OK
@@ -872,7 +872,7 @@ paths:
               schema:
                 $ref: './config_schema.yml#/components/schemas/PlatformSharingPurposes'
         '404':
-          description: A purposeName was present, but the identified platform sharing purpose is unknown.
+          description: A purposeId was present, but the identified platform sharing purpose is unknown.
         '500':
           description: An internal error occured trying to retrieve the requested platform sharing purpose.
 
@@ -907,11 +907,11 @@ paths:
       operationId: getConsentedSharing
       parameters:
         - in: query
-          name: purposeName
+          name: purposeId
           schema:
             type: string
           required: false
-          description: if present, only the named purpose will be returned
+          description: if present, only the identified purpose will be returned
       responses:
         '200':
           description: OK
@@ -920,7 +920,7 @@ paths:
               schema:
                 $ref: './config_schema.yml#/components/schemas/ConsentedSharingPurposes'
         '404':
-          description: A purposeName was present, but the identified consented sharing purpose is unknown.
+          description: A purposeId was present, but the identified consented sharing purpose is unknown.
         '500':
           description: An internal error occured trying to retrieve the requested consented sharing purpose.
 
@@ -932,7 +932,7 @@ paths:
       parameters:
         - $ref: './config_schema.yml#/components/parameters/MinorChangeQueryParameter'
       requestBody:
-        description: the third party groups
+        description: the third party purposes
         required: true
         content:
           application/json:
@@ -955,11 +955,11 @@ paths:
       operationId: getContractualExchange
       parameters:
         - in: query
-          name: purposeName
+          name: purposeId
           schema:
             type: string
           required: false
-          description: if present, only the named purpose will be returned
+          description: if present, only the identified purpose will be returned
       responses:
         '200':
           description: OK
@@ -968,7 +968,7 @@ paths:
               schema:
                 $ref: './config_schema.yml#/components/schemas/ContractualExchangePurposes'
         '404':
-          description: A purpose was present but is unknown.
+          description: A purposeId was present, but the identified contractual exchange purpose is unknown.
         '500':
           description: An internal error occured trying to retrieve the requested contractual exchange purpose.
 
@@ -1286,15 +1286,12 @@ components:
     #
 
     PurposeQueryParameter:
-      name: purpose
+      name: purposeId
       in: query
       required: false
       description: |
         The purpose of the request. No purpose is required for the `userAccess` request type. For all other request
-        types a valid purpose is required.
-
-        For `platformUse` and `platfromSharing` the purpose must be one of the purposes named in configuration. For
-        `contractualExchange` and `consentedSharing` the purpose must be one of the groups named in configuration. 
+        types, a valid purpose identified in the given type is required.
       schema:
         type: string
 
@@ -1327,9 +1324,10 @@ components:
         The requestor who is asserting the given purpose for the given type of request. No subject is required for
         the `platformUse` type. For all other request types a valid subject is required.
 
-        For `platformSharing` the subject must be one of the third parties from the stated purpose. For `userAccess` the
-        subject must be a user provisioned via [upsertUser()](#api-User-upsertUser). For `contractualExchange` and
-        `consentedSharing` the subject must part of the identified purpose group.
+        For `platformSharing` the subject must be the identifier for one of the third parties supporting the stated
+        purpose. For `userAccess` the subject must be a user provisioned via [upsertUser()](#api-User-upsertUser).
+        For `contractualExchange` and `consentedSharing` the subject must identify a specific set of terms from
+        the identified purpose.
       schema:
         type: string
 
@@ -1366,10 +1364,10 @@ components:
     ContractualRelationship:
       type: object
       properties:
-        purpose:
+        purposeId:
           type: string
           description: the purpose of the contractual relationship
-        terms:
+        termsId:
           type: string
           description: the terms of the contractual relationship
       required:
@@ -1417,10 +1415,10 @@ components:
     AffirmativeConsentRelationship:
       type: object
       properties:
-        purpose:
+        purposeId:
           type: string
           description: the purpose of the consented sharing
-        terms:
+        termsId:
           type: string
           description: the terms describing this consented sharing
         categories:
@@ -1459,7 +1457,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PersonalSharingRelationship'
-        optIns:
+        optInIds:
           type: array
           description: a list of all the opt-in purposes the user consented to
           items:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -217,8 +217,8 @@ paths:
                 optIns:
                   - 'Marketing Email'
                 affirmativeConsents:
-                  - purpose: 'Train Algorithm'
-                    terms: 'AI startup3'
+                  - purposeId: 'TrainAlgorithm'
+                    termsId: 'AIstartup3'
                     categories:
                       - email
                       - address
@@ -721,6 +721,8 @@ paths:
           description: OK
         '400':
           description: error reading or parsing the request body, any error message will be in the response body
+        '409':
+          description: the request included a new category or field with a non-unique stable identifier
         '500':
           description: an internal error occurred, any error message will be in the response body
 
@@ -847,6 +849,8 @@ paths:
           description: OK
         '400':
           description: error reading or parsing the request body, any error message will be in the response body
+        '409':
+          description: the request included a new purpose with a non-unique stable identifier
         '500':
           description: an internal error occurred, any error message will be in the response body
 
@@ -895,6 +899,8 @@ paths:
           description: OK
         '400':
           description: error reading or parsing the request body, any error message will be in the response body
+        '409':
+          description: the request included a new purpose or third-party with a non-unique stable identifier
         '500':
           description: an internal error occurred, any error message will be in the response body
   
@@ -943,6 +949,8 @@ paths:
           description: OK
         '400':
           description: error reading or parsing the request body, any error message will be in the response body
+        '409':
+          description: the request included a new purpose or terms with a non-unique stable identifier
         '500':
           description: an internal error occurred, any error message will be in the response body
   
@@ -995,6 +1003,8 @@ paths:
           description: OK
         '400':
           description: error reading or parsing the request body, any error message will be in the response body
+        '409':
+          description: the request included a new purpose or terms with a non-unique stable identifier
         '500':
           description: an internal error occurred, any error message will be in the response body
   


### PR DESCRIPTION
In the lead-up to freezing the v1 API, this PR defines a new component for anything that can be referenced via a stable identifier. E.g., purposes, third-parties, and terms now have a `stableId` field, and property names have been updated to clarify that references are to that ID and not to names.

When the API implementation is updated, it should also be reflected in the context model. E.g., a user should have contractual or consent relationships to terms based on the ID, not the name.

@trek-td - in a discussion on a separate PR I asked whether `categories` should be `categoryIds` but we didn't make that change. LMK if you think I should make that change in this PR, since I think it's now the only property not using this pattern.