### PR TITLE
A few lingering changes from the API alignment work.

### DIFF
--- a/config_schema.yml
+++ b/config_schema.yml
@@ -99,7 +99,7 @@ components:
             propertyName:
               type: string
               enum:
-                - dob
+                - age
                 - location
               description: The name of a user property
             values:
@@ -293,7 +293,7 @@ components:
             propertyName:
               type: string
               enum:
-                - dob
+                - age
                 - location
               description: The name of a user property
             values:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1398,7 +1398,17 @@ components:
         platformSharing:
           $ref: './config_schema.yml#/components/schemas/PlatformSharingPurposes'
         userAccess:
-          $ref: './config_schema.yml#/components/schemas/UserAccess'
+          type: object
+          title: PersonalizedUserCategories
+          properties:
+            categoryIds:
+              description: The set of categories that this user has access to
+              $ref: './config_schema.yml#/components/schemas/CategoryIdentifiers'
+            guardianAccessCategroryIds:
+              description: The set of categories (if any) that this user's guardians have access to
+              $ref: './config_schema.yml#/components/schemas/CategoryIdentifiers'
+          required:
+            - categoryIds
         contractualExchange:
           allOf:
             - $ref: '#/components/schemas/ContractualRelationship'


### PR DESCRIPTION
This PR does three small things:

1. Fixes an attribute enum
2. Simplifies personalized user access to only include categories
3. Extends personalized user access to optionally include guardian access

@trek-td - in the spirit of what we agreed for 2 (keep it as simple as possible until we flesh out user interaction) I also picked the simplest model I could think of for 3. Because personalized terms are provided so a user can agree to how _their_ data is being used, we don't need to change what a guardian sees. The contract with 3 is that it would only be included if there are guardian terms, and if the user being presented terms is under the threshold age, regardless of whether the user currently has any guardian relationships since we're saying "by being under-age on our platform, any guardian associated with you will have access to the following categories." Let me know if that makes sense?